### PR TITLE
Revamp theme with gradient backgrounds

### DIFF
--- a/lib/game/game_page.dart
+++ b/lib/game/game_page.dart
@@ -209,71 +209,80 @@ class _GamePageState extends State<GamePage> {
           ),
         ],
       ),
-      body: q == null
-          ? const Center(child: CircularProgressIndicator())
-          : Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Text(
-                    'Score: $score',
-                    style: Theme.of(context).textTheme.titleMedium,
-                  ),
-                  const SizedBox(height: 12),
-                  Card(
-                    child: Padding(
-                      padding: const EdgeInsets.all(16.0),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.stretch,
-                        children: [
-                          Text(
-                            'Which department matches code: ',
-                            style: Theme.of(context).textTheme.titleMedium,
-                          ),
-                          const SizedBox(height: 8),
-                          Text(
-                            q.target.code,
-                            style: Theme.of(context).textTheme.displaySmall
-                                ?.copyWith(fontWeight: FontWeight.bold),
-                          ),
-                        ],
-                      ),
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFF7C3AED), Color(0xFF4F46E5)],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: q == null
+            ? const Center(child: CircularProgressIndicator())
+            : Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Text(
+                      'Score: $score',
+                      style: Theme.of(context).textTheme.titleMedium,
                     ),
-                  ),
-                  const SizedBox(height: 12),
-                  for (int i = 0; i < q.options.length; i++) ...[
-                    Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 6.0),
-                      child: OutlinedButton(
-                        onPressed: () => _answer(i),
-                        child: Padding(
-                          padding: const EdgeInsets.all(12.0),
-                          child: Text(q.options[i]),
+                    const SizedBox(height: 12),
+                    Card(
+                      child: Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            Text(
+                              'Which department matches code: ',
+                              style: Theme.of(context).textTheme.titleMedium,
+                            ),
+                            const SizedBox(height: 8),
+                            Text(
+                              q.target.code,
+                              style: Theme.of(context).textTheme.displaySmall
+                                  ?.copyWith(fontWeight: FontWeight.bold),
+                            ),
+                          ],
                         ),
                       ),
                     ),
-                  ],
-                  const Spacer(),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Text('Questions: $total'),
-                      Row(
-                        children: [
-                          IconButton(
-                            tooltip: 'Use 50/50 hint (remaining: $hints)',
-                            onPressed: _useHint,
-                            icon: const Icon(Icons.lightbulb_outline),
+                    const SizedBox(height: 12),
+                    for (int i = 0; i < q.options.length; i++) ...[
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 6.0),
+                        child: OutlinedButton(
+                          onPressed: () => _answer(i),
+                          child: Padding(
+                            padding: const EdgeInsets.all(12.0),
+                            child: Text(q.options[i]),
                           ),
-                          Text('x$hints'),
-                        ],
+                        ),
                       ),
                     ],
-                  ),
-                ],
+                    const Spacer(),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text('Questions: $total'),
+                        Row(
+                          children: [
+                            IconButton(
+                              tooltip: 'Use 50/50 hint (remaining: $hints)',
+                              onPressed: _useHint,
+                              icon: const Icon(Icons.lightbulb_outline),
+                            ),
+                            Text('x$hints'),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
               ),
-            ),
+      ),
     );
   }
 }

--- a/lib/game/home_page.dart
+++ b/lib/game/home_page.dart
@@ -7,34 +7,43 @@ class HomePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Departments Blitz')),
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(24.0),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              const Text(
-                '60-second sprint. Match the code to the department name.',
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 24),
-              FilledButton(
-                onPressed: () => Navigator.of(context).pushNamed('/game'),
-                child: const Text('Play Sprint (60s)'),
-              ),
-              const SizedBox(height: 8),
-              TextButton(
-                onPressed: () => showAboutDialog(
-                  context: context,
-                  applicationName: 'Departments Blitz',
-                  applicationVersion: '1.0.0',
-                  children: const [
-                    Text('Ads: interstitial on results; rewarded for hints.'),
-                  ],
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFF7C3AED), Color(0xFF4F46E5)],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(24.0),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const Text(
+                  '60-second sprint. Match the code to the department name.',
+                  textAlign: TextAlign.center,
                 ),
-                child: const Text('About'),
-              ),
-            ],
+                const SizedBox(height: 24),
+                FilledButton(
+                  onPressed: () => Navigator.of(context).pushNamed('/game'),
+                  child: const Text('Play Sprint (60s)'),
+                ),
+                const SizedBox(height: 8),
+                TextButton(
+                  onPressed: () => showAboutDialog(
+                    context: context,
+                    applicationName: 'Departments Blitz',
+                    applicationVersion: '1.0.0',
+                    children: const [
+                      Text('Ads: interstitial on results; rewarded for hints.'),
+                    ],
+                  ),
+                  child: const Text('About'),
+                ),
+              ],
+            ),
           ),
         ),
       ),

--- a/lib/game/results_page.dart
+++ b/lib/game/results_page.dart
@@ -65,34 +65,43 @@ class _ResultsPageState extends State<ResultsPage> {
         : ((widget.score / (widget.total * 10)) * 100).round();
     return Scaffold(
       appBar: AppBar(title: const Text('Results')),
-      body: Padding(
-        padding: const EdgeInsets.all(24.0),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Text('Score', style: Theme.of(context).textTheme.titleLarge),
-            Text(
-              '${widget.score}',
-              style: Theme.of(context).textTheme.displayMedium,
-            ),
-            const SizedBox(height: 8),
-            Text('Questions answered: ${widget.total}'),
-            Text('Accuracy: $acc%'),
-            const SizedBox(height: 24),
-            FilledButton(
-              onPressed: () => _showInterstitialThen(
-                () => Navigator.of(context).pushReplacementNamed('/game'),
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [Color(0xFF7C3AED), Color(0xFF4F46E5)],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text('Score', style: Theme.of(context).textTheme.titleLarge),
+              Text(
+                '${widget.score}',
+                style: Theme.of(context).textTheme.displayMedium,
               ),
-              child: const Text('Play again'),
-            ),
-            const SizedBox(height: 8),
-            TextButton(
-              onPressed: () => _showInterstitialThen(
-                () => Navigator.of(context).pushReplacementNamed('/'),
+              const SizedBox(height: 8),
+              Text('Questions answered: ${widget.total}'),
+              Text('Accuracy: $acc%'),
+              const SizedBox(height: 24),
+              FilledButton(
+                onPressed: () => _showInterstitialThen(
+                  () => Navigator.of(context).pushReplacementNamed('/game'),
+                ),
+                child: const Text('Play again'),
               ),
-              child: const Text('Back to Home'),
-            ),
-          ],
+              const SizedBox(height: 8),
+              TextButton(
+                onPressed: () => _showInterstitialThen(
+                  () => Navigator.of(context).pushReplacementNamed('/'),
+                ),
+                child: const Text('Back to Home'),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,7 +28,31 @@ class BlitzApp extends StatelessWidget {
       title: 'Departments Blitz',
       theme: ThemeData(
         useMaterial3: true,
-        colorSchemeSeed: const Color(0xFF3B82F6),
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: const Color(0xFF7C3AED),
+        ),
+        filledButtonTheme: FilledButtonThemeData(
+          style: FilledButton.styleFrom(
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+          ),
+        ),
+        outlinedButtonTheme: OutlinedButtonThemeData(
+          style: OutlinedButton.styleFrom(
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+            ),
+          ),
+        ),
+        cardTheme: CardTheme(
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(20),
+          ),
+          elevation: 4,
+        ),
       ),
       routes: {
         '/': (_) => const HomePage(),


### PR DESCRIPTION
## Summary
- Refresh Material theme with new purple color scheme and refined button/card styling
- Add vibrant gradient backgrounds to home, game, and results screens for a modern feel

## Testing
- `dart format lib/main.dart lib/game/home_page.dart lib/game/game_page.dart lib/game/results_page.dart` (fails: No such file or directory)
- `flutter analyze` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68a4d4c29788832cbc58b3a89d9722d2