### PR TITLE
refactor: extract gradient background widget

### DIFF
--- a/lib/game/game_page.dart
+++ b/lib/game/game_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import '../ad_helper.dart';
+import '../widgets/gradient_background.dart';
 import 'models.dart';
 import 'quiz_engine.dart';
 
@@ -209,14 +210,7 @@ class _GamePageState extends State<GamePage> {
           ),
         ],
       ),
-      body: Container(
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            colors: [Color(0xFF7C3AED), Color(0xFF4F46E5)],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-          ),
-        ),
+      body: GradientBackground(
         child: q == null
             ? const Center(child: CircularProgressIndicator())
             : Padding(

--- a/lib/game/home_page.dart
+++ b/lib/game/home_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../widgets/gradient_background.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
@@ -7,14 +8,7 @@ class HomePage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Departments Blitz')),
-      body: Container(
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            colors: [Color(0xFF7C3AED), Color(0xFF4F46E5)],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-          ),
-        ),
+      body: GradientBackground(
         child: Center(
           child: Padding(
             padding: const EdgeInsets.all(24.0),

--- a/lib/game/results_page.dart
+++ b/lib/game/results_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import '../ad_helper.dart';
+import '../widgets/gradient_background.dart';
 
 class ResultsPage extends StatefulWidget {
   final int score;
@@ -65,14 +66,7 @@ class _ResultsPageState extends State<ResultsPage> {
         : ((widget.score / (widget.total * 10)) * 100).round();
     return Scaffold(
       appBar: AppBar(title: const Text('Results')),
-      body: Container(
-        decoration: const BoxDecoration(
-          gradient: LinearGradient(
-            colors: [Color(0xFF7C3AED), Color(0xFF4F46E5)],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-          ),
-        ),
+      body: GradientBackground(
         child: Padding(
           padding: const EdgeInsets.all(24.0),
           child: Column(

--- a/lib/widgets/gradient_background.dart
+++ b/lib/widgets/gradient_background.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class GradientBackground extends StatelessWidget {
+  final Widget child;
+
+  const GradientBackground({super.key, required this.child});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: const BoxDecoration(
+        gradient: LinearGradient(
+          colors: [Color(0xFF7C3AED), Color(0xFF4F46E5)],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+      ),
+      child: child,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable `GradientBackground` widget
- use `GradientBackground` in home, game, and results pages

## Testing
- `dart format lib/widgets/gradient_background.dart lib/game/home_page.dart lib/game/game_page.dart lib/game/results_page.dart` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d79c0ca0832c88eb2b6a0db55bcc