### PR TITLE
Randomize 50-50 hint and add randomness test

### DIFF
--- a/lib/game/game_page.dart
+++ b/lib/game/game_page.dart
@@ -1,9 +1,27 @@
 import 'dart:async';
+import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import '../ad_helper.dart';
 import 'models.dart';
 import 'quiz_engine.dart';
+
+QuizQuestion applyFiftyFiftyToQuestion(QuizQuestion q, Random rand) {
+  final correctIdx = q.correctIndex;
+  final wrongIndices = <int>[];
+  for (int i = 0; i < q.options.length; i++) {
+    if (i != correctIdx) wrongIndices.add(i);
+  }
+  final keepWrongIdx = wrongIndices[rand.nextInt(wrongIndices.length)];
+  final newOpts = [q.options[correctIdx], q.options[keepWrongIdx]];
+  newOpts.shuffle(rand);
+  final newCorrectIdx = newOpts.indexOf(q.options[correctIdx]);
+  return QuizQuestion(
+    target: q.target,
+    options: newOpts,
+    correctIndex: newCorrectIdx,
+  );
+}
 
 class GamePage extends StatefulWidget {
   final List<Department> departments;
@@ -73,28 +91,13 @@ class _GamePageState extends State<GamePage> {
     });
   }
 
-  // 50/50 hint: keep correct + one wrong
+  // 50/50 hint: keep correct + one random wrong option
   void _applyFiftyFifty() {
     if (current == null || _fiftyUsedOnThisQ) return;
     final q = current!;
-    final correctIdx = q.correctIndex;
-    final List<String> newOpts = [q.options[correctIdx]];
-    // pick a random wrong option to keep
-    for (int i = 0; i < q.options.length; i++) {
-      if (i != correctIdx) {
-        newOpts.add(q.options[i]);
-        break;
-      }
-    }
-    newOpts.shuffle();
-    final newCorrectIdx = newOpts.indexOf(q.options[correctIdx]);
-
+    final rand = Random();
     setState(() {
-      current = QuizQuestion(
-        target: q.target,
-        options: newOpts,
-        correctIndex: newCorrectIdx,
-      );
+      current = applyFiftyFiftyToQuestion(q, rand);
       _fiftyUsedOnThisQ = true;
     });
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^3.0.1
+  test: ^1.24.0
 
 flutter:
   uses-material-design: true

--- a/test/fifty_fifty_test.dart
+++ b/test/fifty_fifty_test.dart
@@ -1,0 +1,24 @@
+import 'dart:math';
+
+import 'package:departments_blitz/game/game_page.dart';
+import 'package:departments_blitz/game/models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('50/50 retains varying wrong options', () {
+    final question = QuizQuestion(
+      target: const Department(code: 'CS', name: 'Computer Science'),
+      options: const ['Correct', 'Wrong1', 'Wrong2'],
+      correctIndex: 0,
+    );
+    final keptWrong = <String>{};
+    for (int i = 0; i < 100; i++) {
+      final result = applyFiftyFiftyToQuestion(question, Random(i));
+      final wrong =
+          result.options.firstWhere((opt) => opt != 'Correct');
+      keptWrong.add(wrong);
+    }
+    expect(keptWrong.length, greaterThan(1));
+  });
+}
+


### PR DESCRIPTION
## Summary
- randomize 50/50 hint by collecting all wrong options and keeping one at random
- expose reusable `applyFiftyFiftyToQuestion` helper
- add unit test ensuring different wrong answers can be kept

## Testing
- `dart format lib/game/game_page.dart test/fifty_fifty_test.dart pubspec.yaml` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d79dc198832cbd21b3eb5d1c0f3f