### PR TITLE
Gracefully handle department loading errors

### DIFF
--- a/lib/game/models.dart
+++ b/lib/game/models.dart
@@ -21,8 +21,12 @@ class QuizQuestion {
 }
 
 List<Department> parseDepartmentsJson(String jsonStr) {
-  final List<dynamic> arr = json.decode(jsonStr) as List<dynamic>;
-  return arr
-      .map((e) => Department.fromJson(e as Map<String, dynamic>))
-      .toList();
+  try {
+    final List<dynamic> arr = json.decode(jsonStr) as List<dynamic>;
+    return arr
+        .map((e) => Department.fromJson(e as Map<String, dynamic>))
+        .toList();
+  } catch (e) {
+    throw FormatException('Failed to parse departments JSON: $e');
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,15 +7,48 @@ import 'game/results_page.dart';
 import 'game/models.dart';
 
 Future<List<Department>> loadDepartments() async {
-  final jsonStr = await rootBundle.loadString('assets/departments.json');
-  return parseDepartmentsJson(jsonStr);
+  try {
+    final jsonStr = await rootBundle.loadString('assets/departments.json');
+    return parseDepartmentsJson(jsonStr);
+  } on FlutterError catch (e) {
+    throw FlutterError('Failed to load departments asset: ${e.message}');
+  } on FormatException catch (e) {
+    throw FormatException('Failed to parse departments: ${e.message}');
+  }
 }
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await MobileAds.instance.initialize();
-  final departments = await loadDepartments();
-  runApp(BlitzApp(departments: departments));
+  try {
+    final departments = await loadDepartments();
+    runApp(BlitzApp(departments: departments));
+  } on FlutterError catch (e) {
+    runApp(ErrorApp(message: e.message));
+  } on FormatException catch (e) {
+    runApp(ErrorApp(message: e.message));
+  }
+}
+
+class ErrorApp extends StatelessWidget {
+  final String message;
+  const ErrorApp({super.key, required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Departments Blitz - Error',
+      home: Scaffold(
+        appBar: AppBar(title: const Text('Error')),
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Text(message, textAlign: TextAlign.center),
+          ),
+        ),
+      ),
+    );
+  }
 }
 
 class BlitzApp extends StatelessWidget {


### PR DESCRIPTION
## Summary
- Catch asset and JSON parsing failures during department load and surface clear `FlutterError`/`FormatException` messages.
- Wrap main startup in error handling and show a simple error screen when loading departments fails.
- Improve JSON parsing in `parseDepartmentsJson` to throw a descriptive `FormatException` on decoding issues.

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d79e9ad8832cacfd8cf273433449