### PR TITLE
Use typed arguments for results routing

### DIFF
--- a/lib/game/game_page.dart
+++ b/lib/game/game_page.dart
@@ -4,6 +4,7 @@ import 'package:google_mobile_ads/google_mobile_ads.dart';
 import '../ad_helper.dart';
 import 'models.dart';
 import 'quiz_engine.dart';
+import 'results_args.dart';
 
 class GamePage extends StatefulWidget {
   final List<Department> departments;
@@ -51,7 +52,7 @@ class _GamePageState extends State<GamePage> {
     if (!mounted) return;
     Navigator.of(context).pushReplacementNamed(
       '/results',
-      arguments: {'score': score, 'total': total},
+      arguments: ResultsArgs(score: score, total: total),
     );
   }
 

--- a/lib/game/results_args.dart
+++ b/lib/game/results_args.dart
@@ -1,0 +1,5 @@
+class ResultsArgs {
+  final int score;
+  final int total;
+  const ResultsArgs({required this.score, required this.total});
+}

--- a/lib/game/results_page.dart
+++ b/lib/game/results_page.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import '../ad_helper.dart';
+import 'results_args.dart';
 
 class ResultsPage extends StatefulWidget {
-  final int score;
-  final int total;
-  const ResultsPage({super.key, required this.score, required this.total});
+  final ResultsArgs args;
+  const ResultsPage({super.key, required this.args});
 
   @override
   State<ResultsPage> createState() => _ResultsPageState();
@@ -60,9 +60,9 @@ class _ResultsPageState extends State<ResultsPage> {
 
   @override
   Widget build(BuildContext context) {
-    final acc = widget.total == 0
+    final acc = widget.args.total == 0
         ? 0
-        : ((widget.score / (widget.total * 10)) * 100).round();
+        : ((widget.args.score / (widget.args.total * 10)) * 100).round();
     return Scaffold(
       appBar: AppBar(title: const Text('Results')),
       body: Container(
@@ -80,11 +80,11 @@ class _ResultsPageState extends State<ResultsPage> {
             children: [
               Text('Score', style: Theme.of(context).textTheme.titleLarge),
               Text(
-                '${widget.score}',
+                '${widget.args.score}',
                 style: Theme.of(context).textTheme.displayMedium,
               ),
               const SizedBox(height: 8),
-              Text('Questions answered: ${widget.total}'),
+              Text('Questions answered: ${widget.args.total}'),
               Text('Accuracy: $acc%'),
               const SizedBox(height: 24),
               FilledButton(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'game/home_page.dart';
 import 'game/game_page.dart';
 import 'game/results_page.dart';
 import 'game/models.dart';
+import 'game/results_args.dart';
 
 Future<List<Department>> loadDepartments() async {
   final jsonStr = await rootBundle.loadString('assets/departments.json');
@@ -60,11 +61,11 @@ class BlitzApp extends StatelessWidget {
       },
       onGenerateRoute: (settings) {
         if (settings.name == '/results') {
-          final args = settings.arguments as Map<String, dynamic>?;
-          final score = args?['score'] as int? ?? 0;
-          final total = args?['total'] as int? ?? 0;
+          final args = settings.arguments as ResultsArgs?;
           return MaterialPageRoute(
-            builder: (_) => ResultsPage(score: score, total: total),
+            builder: (_) => ResultsPage(
+              args: args ?? const ResultsArgs(score: 0, total: 0),
+            ),
           );
         }
         return null;


### PR DESCRIPTION
## Summary
- add `ResultsArgs` class for score and total
- pass `ResultsArgs` when navigating to results
- update route generation and `ResultsPage` to use `ResultsArgs`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d7a42180832ca87726ef6f4ed8c7