### PR TITLE
Fix quiz engine and theme compilation issues

### DIFF
--- a/lib/game/quiz_engine.dart
+++ b/lib/game/quiz_engine.dart
@@ -31,8 +31,7 @@ class QuizEngine {
     while (opts.length < optionsCount - 1) {
       final d = all[_rng.nextInt(all.length)];
 
-      if (d.name != correctName && !used.contains(d.name)) {
-
+      if (d.name != target.name && !used.contains(d.name)) {
         used.add(d.name);
         opts.add(d.name);
       }

--- a/lib/game/results_page.dart
+++ b/lib/game/results_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:google_mobile_ads/google_mobile_ads.dart';
 import '../ad_helper.dart';
 import 'results_args.dart';
+import '../widgets/gradient_background.dart';
 
 
 class ResultsPage extends StatefulWidget {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -81,7 +81,7 @@ class BlitzApp extends StatelessWidget {
             ),
           ),
         ),
-        cardTheme: CardTheme(
+        cardTheme: CardThemeData(
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(20),
           ),


### PR DESCRIPTION
## Summary
- Ensure distractor selection excludes the target department
- Import the `GradientBackground` widget on the results page
- Update app theme to use `CardThemeData`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dec6ef34832ca92b9bbdf9213bbf