### PR TITLE
Reduce sprint quiz to 20 seconds

### DIFF
--- a/lib/game/game_page.dart
+++ b/lib/game/game_page.dart
@@ -40,7 +40,7 @@ class _GamePageState extends State<GamePage> {
   int total = 0;
   int hints = 1; // start with 1; more via rewarded
   Timer? _timer;
-  int secondsLeft = 60;
+  int secondsLeft = 20;
   bool _fiftyUsedOnThisQ = false;
 
   RewardedAd? _rewardedAd;
@@ -204,7 +204,7 @@ class _GamePageState extends State<GamePage> {
     final q = current;
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Sprint (60s)'),
+        title: const Text('Sprint (20s)'),
         actions: [
           Center(
             child: Padding(

--- a/lib/game/home_page.dart
+++ b/lib/game/home_page.dart
@@ -16,13 +16,13 @@ class HomePage extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 const Text(
-                  '60-second sprint. Match the code to the department name.',
+                  '20-second sprint. Match the code to the department name.',
                   textAlign: TextAlign.center,
                 ),
                 const SizedBox(height: 24),
                 FilledButton(
                   onPressed: () => Navigator.of(context).pushNamed('/game'),
-                  child: const Text('Play Sprint (60s)'),
+                  child: const Text('Play Sprint (20s)'),
                 ),
                 const SizedBox(height: 8),
                 TextButton(


### PR DESCRIPTION
## Summary
- Update sprint quiz description and play button to 20 seconds
- Adjust game timer and app bar title for 20-second sprint

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a4e1769afc832cad5fb62902418390