### PR TITLE
Refine app color palette

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -63,7 +63,7 @@ class BlitzApp extends StatelessWidget {
       theme: ThemeData(
         useMaterial3: true,
         colorScheme: ColorScheme.fromSeed(
-          seedColor: const Color(0xFF7C3AED),
+          seedColor: const Color(0xFF1E3A8A),
         ),
         filledButtonTheme: FilledButtonThemeData(
           style: FilledButton.styleFrom(

--- a/lib/widgets/gradient_background.dart
+++ b/lib/widgets/gradient_background.dart
@@ -10,7 +10,7 @@ class GradientBackground extends StatelessWidget {
     return Container(
       decoration: const BoxDecoration(
         gradient: LinearGradient(
-          colors: [Color(0xFF7C3AED), Color(0xFF4F46E5)],
+          colors: [Color(0xFF1E3A8A), Color(0xFF3B82F6)],
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
         ),


### PR DESCRIPTION
## Summary
- adopt deep blue gradient for background
- seed theme with navy tone for modern look

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e196bc98832ca50c2f4947726b39